### PR TITLE
shorten ping interval

### DIFF
--- a/lib/AnySan/Provider/Slack.pm
+++ b/lib/AnySan/Provider/Slack.pm
@@ -38,7 +38,7 @@ sub slack {
     my $rtm = AnyEvent::SlackRTM->new($config{token});
     $rtm->on('hello' => sub {
         $self->{keep_alive} = AnyEvent->timer(
-            interval => 60,
+            interval => 29,
             cb => sub {
                 $rtm->ping;
             },


### PR DESCRIPTION
The client sometimes times out because it is not pinging frequently enough to get valid websocket urls.

`EV: error in callback (ignoring): Cannot send because the connection is finished at /home/app/perl5/perl-5.16.3/lib/site_perl/5.16.3/AnySan/Provider/Slack.pm line 43`

According to the [documentation](https://api.slack.com/rtm) : The Websocket URLs provided by rtm.start are single-use and are only valid for 30 seconds
