### PR TITLE
Add timeout option to slackrtm

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'perl', '5.008001';
 
 requires 'AnySan';
 requires 'AnyEvent::HTTP';
-requires 'AnyEvent::SlackRTM';
+requires 'AnyEvent::SlackRTM', ">=1.2";
 requires 'HTTP::Request::Common';
 requires 'JSON';
 

--- a/lib/AnySan/Provider/Slack.pm
+++ b/lib/AnySan/Provider/Slack.pm
@@ -49,8 +49,8 @@ sub bot {
 sub start {
     my $self = shift;
 
-    my $timeout = $self->{config}{timeout} ? { timeout => $self->{config}{timeout} } : undef;
-    my $rtm = AnyEvent::SlackRTM->new($self->{config}{token}, $timeout);
+    my $client_opt = $self->{config}{timeout} ? { timeout => $self->{config}{timeout} } : undef;
+    my $rtm = AnyEvent::SlackRTM->new($self->{config}{token}, $client_opt);
     $rtm->on('hello' => sub {
         # create hash table of users
         my $users = {};

--- a/lib/AnySan/Provider/Slack.pm
+++ b/lib/AnySan/Provider/Slack.pm
@@ -49,7 +49,8 @@ sub bot {
 sub start {
     my $self = shift;
 
-    my $rtm = AnyEvent::SlackRTM->new($self->{config}{token});
+    my $timeout = $self->{config}{timeout} ? { timeout => $self->{config}{timeout} } : undef;
+    my $rtm = AnyEvent::SlackRTM->new($self->{config}{token}, $timeout);
     $rtm->on('hello' => sub {
         # create hash table of users
         my $users = {};


### PR DESCRIPTION
Added timeout option to slackrtm because if the api response is too large, a timeout causes

The other day, I had [this PR fix](https://github.com/zostay/AnyEvent-SlackRTM/pull/12) merged and released AnyEvent-SlackRTM 1.2. By combining AnyEvent-SlackRTM 1.2, the timeout of internal Furl communication will be controllable.

It uses existing options, so there's no backwards compatibility issue.